### PR TITLE
Added pos tagging.

### DIFF
--- a/test/corenlp_test.clj
+++ b/test/corenlp_test.clj
@@ -6,7 +6,12 @@
 (deftest tokenize-test
   (testing "tokenize"
     (is (= (map corenlp/word ["Petunia" "is" "my" "cat" "."])
-           (corenlp/tokenize "Petunia is my cat.")))))
+           (corenlp/tokenize "Petunia is my cat."))))
+  (testing "tokenize-core-label"
+    (let [tokens (corenlp/tokenize-core-label "Petunia is my cat.")]
+      (is (every? #(instance? edu.stanford.nlp.ling.CoreLabel %) tokens))
+      (is (= ["Petunia" "is" "my" "cat" "."]
+             (map str tokens))))))
 
 
 (deftest split-sentences-test
@@ -19,11 +24,8 @@
 
 (deftest pos-tagging-test
   (testing "pos-tag"
-    (let [tagged-words (corenlp/pos-tag
-                        (corenlp/tokenize "Petunia is my cat."))]
-      (is (= (map #(edu.stanford.nlp.ling.TaggedWord. %1 %2)
-                  ["Petunia" "is" "my" "cat" "."]
-                  ["NNP" "VBZ" "PRP$" "NN" "."])
+    (let [tagged-words (corenlp/pos-tag "Petunia is my cat.")]
+      (is (= [["Petunia" "NNP"] ["is" "VBZ"] ["my" "PRP$"] ["cat" "NN"] ["." "."]]
              tagged-words)))))
 
 

--- a/test/corenlp_test.clj
+++ b/test/corenlp_test.clj
@@ -1,0 +1,33 @@
+(ns corenlp-test
+  (:require [corenlp :as corenlp]
+            [clojure.test :refer :all]))
+
+
+(deftest tokenize-test
+  (testing "tokenize"
+    (is (= (map corenlp/word ["Petunia" "is" "my" "cat" "."])
+           (corenlp/tokenize "Petunia is my cat.")))))
+
+
+(deftest split-sentences-test
+  (testing "split-sentences"
+    (let [sent-tokens (corenlp/split-sentences
+                       "Petunia is my cat. She is a DSH.")]
+      (is (= [["Petunia" "is" "my" "cat" "."] ["She" "is" "a" "DSH" "."]]
+             sent-tokens)))))
+
+
+(deftest pos-tagging-test
+  (testing "pos-tag"
+    (let [tagged-words (corenlp/pos-tag
+                        (corenlp/tokenize "Petunia is my cat."))]
+      (is (= (map #(edu.stanford.nlp.ling.TaggedWord. %1 %2)
+                  ["Petunia" "is" "my" "cat" "."]
+                  ["NNP" "VBZ" "PRP$" "NN" "."])
+             tagged-words)))))
+
+
+(deftest parse-test
+  (testing "parse"
+    (is (= "(ROOT (S (NP (NNP Petunia)) (VP (VBZ is) (NP (PRP$ my) (NN cat))) (. .)))"
+           (str (corenlp/parse (corenlp/tokenize "Petunia is my cat.")))))))


### PR DESCRIPTION
This is based on @arnaudsj's fork, but I modified `pos-tag` to return a sequence of [word tag] pairs instead of just a sequence of tags.

That is, instead of

```
(pos-tag "how do i use this?") -> ("WRB" "VBP" "PRP" "VB" "DT" ".")`
```

you get

```
(pos-tag "how do I use this?") -> (["how" "WRB"] ["do" "VBP"] ["I" "PRP"] ["use" "VB"] ["this" "DT"] ["?" "."])
```

which seems much more useful to me.

I'm also probably going to end up removing the multimethods for specialized handling of `ArrayList` because `ArrayList`s of `Word`s seem less useful for POS, NER, sentiment etc. than `CoreLabel`s.
