### PR TITLE
Initialize pipeline changed to accept map of properties 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject org.clojurenlp/core "3.7.0"
+(defproject org.clojurenlp/core "3.7.1"
   :description "Clojure wrapper for the Stanford CoreNLP tools."
   :url "https://github.com/clojurenlp/core"
   :license {:name "Apache License, Version 2.0"
   	        :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [edu.stanford.nlp/stanford-corenlp "3.8.0"]
-                 [edu.stanford.nlp/stanford-corenlp "3.8.0" 
+                 [edu.stanford.nlp/stanford-corenlp "3.9.2"]
+                 [edu.stanford.nlp/stanford-corenlp "3.9.2"
                   :classifier "models"]
                  [org.clojure/data.json "0.2.6"]
                  [aysylu/loom "1.0.0"]

--- a/src/org/clojurenlp/core.clj
+++ b/src/org/clojurenlp/core.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.data.json :as json]
    [clojure.set :as set]
+   [clojure.walk :as walk]
    [loom.attr :as attr]
    [loom.graph :as graph])
   (:import (java.io StringReader)
@@ -136,8 +137,11 @@
      (StanfordCoreNLP. props true)))
 
   ([properties-map]
-   (let [props (Properties.)]
-     (.putAll props (assoc properties-map "annotators" "tokenize, ssplit, pos, lemma, ner"))
+   (let [props (Properties.)
+         stringified-map (walk/stringify-keys properties-map)]
+     (if (nil? (:annotators properties-map))
+       (.putAll props (assoc stringified-map "annotators" "tokenize, ssplit, pos, lemma, ner,pffft"))
+       (.putAll props stringified-map))
      (StanfordCoreNLP. props true))))
 
 (defn- annotate-text

--- a/src/org/clojurenlp/core.clj
+++ b/src/org/clojurenlp/core.clj
@@ -137,8 +137,7 @@
 
   ([properties-map]
    (let [props (Properties.)]
-     (.putAll props properties-map)
-     (.put props "annotators" "tokenize, ssplit, pos, lemma, ner")
+     (.putAll props (assoc properties-map "annotators" "tokenize, ssplit, pos, lemma, ner"))
      (StanfordCoreNLP. props true))))
 
 (defn- annotate-text

--- a/src/org/clojurenlp/core.clj
+++ b/src/org/clojurenlp/core.clj
@@ -140,7 +140,7 @@
    (let [props (Properties.)
          stringified-map (walk/stringify-keys properties-map)]
      (if (nil? (:annotators properties-map))
-       (.putAll props (assoc stringified-map "annotators" "tokenize, ssplit, pos, lemma, ner,pffft"))
+       (.putAll props (assoc stringified-map "annotators" "tokenize, ssplit, pos, lemma, ner"))
        (.putAll props stringified-map))
      (StanfordCoreNLP. props true))))
 

--- a/src/org/clojurenlp/core.clj
+++ b/src/org/clojurenlp/core.clj
@@ -128,18 +128,18 @@
   (tag-words ^Collection coll))
 
 (defn initialize-pipeline
-  "0 Arity: Build NER tagging pipeline; use Stanford model
-   1 Arity: Build NER tagging pipeline; use custom model"
+  "0 Arity: Build pipeline; use default properties including Stanford's model
+   1 Arity: Build pipeline; use custom properties"
   ([]
-   (let [ner-props (Properties.)]
-     (.put ner-props "annotators" "tokenize, ssplit, pos, lemma, ner")
-     (StanfordCoreNLP. ner-props true)))
+   (let [props (Properties.)]
+     (.put props "annotators" "tokenize, ssplit, pos, lemma, ner")
+     (StanfordCoreNLP. props true)))
 
-  ([model-path]
-   (let [ner-props (Properties.)]
-     (.put ner-props "annotators" "tokenize, ssplit, pos, lemma, ner")
-     (.put ner-props "ner.model" model-path)
-     (StanfordCoreNLP. ner-props true))))
+  ([properties-map]
+   (let [props (Properties.)]
+     (.putAll props properties-map)
+     (.put props "annotators" "tokenize, ssplit, pos, lemma, ner")
+     (StanfordCoreNLP. props true))))
 
 (defn- annotate-text
   "Annotates text tokens with named entity type.


### PR DESCRIPTION
-Updated Stanford corenlp version
-Changed 1 arity parameter for `initialize-pipeline` to be a map of properties